### PR TITLE
changed setup.py to remove previous errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ setuptools.setup(
     keywords='binod',
     install_requires=[
       'wget',
-      'futures',
       'tqdm',
-      'times',
-      'functools'
     ],    
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setuptools.setup(
       'wget',
       'futures',
       'tqdm',
-      'os-sys',
       'times',
       'functools'
     ],    


### PR DESCRIPTION
Previously I added this in the setup.py file
```python
    install_requires=[
      'wget',
      'futures',
      'tqdm',
      'times',
      'functools'
    ], 
```
I guess because of this it was giving some version error
<img src="https://i.ibb.co/BLvwsB9/Screenshot-1103.png">
So I have removed some libraries, now it's working. It would be better if you can check and confirm.